### PR TITLE
fix(67): Match Jira ticket numbers which usually have upper case letters

### DIFF
--- a/src/main/js/steps/analyze.js
+++ b/src/main/js/steps/analyze.js
@@ -49,7 +49,7 @@ export const getSemanticChanges = async (cwd, from, to, rules = semanticRules) =
 export const analyzeCommits = (commits, rules) =>
   commits.reduce((acc, {subj, body, short, hash}) => {
     rules.forEach(({group, releaseType, prefixes, keywords}) => {
-      const prefixMatcher = prefixes && new RegExp(`^(${prefixes.join('|')})(\\([a-z0-9\\-_,]+\\))?:\\s.+$`)
+      const prefixMatcher = prefixes && new RegExp(`^(${prefixes.join('|')})(\\([a-zA-Z0-9\\-_,]+\\))?:\\s.+$`)
       const keywordsMatcher = keywords && new RegExp(`(${keywords.join('|')}):\\s(.+)`)
       const change = subj.match(prefixMatcher)?.[0] || body.match(keywordsMatcher)?.[2]
 


### PR DESCRIPTION
Fixes [#67]

Allow upper case letters to be matched, this is necessary for Jira ticket IDs such like "ABC-123".

## Changes
Updated prefix matcher regexp to include upper case letters.

- [ ] New code is covered by tests
- [ ] All the changes are mentioned in docs (readme.md)
